### PR TITLE
Update upsun.json: require web.locations.root

### DIFF
--- a/validator/schema/upsun.json
+++ b/validator/schema/upsun.json
@@ -354,6 +354,9 @@
                 "description": "More information: \nhttps://docs.upsun.com/create-apps/app-reference/single-runtime-image.html#web",
                 "default": {}
               },
+              "required": [
+                "root"
+              ],
               "commands": {
                 "type": "object",
                 "properties": {


### PR DESCRIPTION
This is a required setting. 
If not set, it raises a HTTP 502 error and we need to raise an error during YAML validation.